### PR TITLE
Easier usage of url builder

### DIFF
--- a/util/url/builder.js
+++ b/util/url/builder.js
@@ -12,6 +12,9 @@ module.exports = function(url, method){
    * @return {function} returns a function which takes the URL as parameters.
    */
   return function generateUrl(param){
+    if (param == undefined) {
+      param = {};
+    }
     return {
       url: urlProcessor(url, param.urlData),
       method: method,


### PR DESCRIPTION
The url builder is not able to handle a request without any data set.
[It](https://github.com/KleeGroup/focus/blob/48b1df1d76759e7246aa579369c87e19dfc0daed/util/url/builder.js) tries to evaluate `param.urlData` from the given argument `param`, which means it is mandatory to provide an object to the builder, even if it is empty.
For instance, `focus.util.url.builder('route', 'method')()` will throw a `Uncaught TypeError: Cannot read property 'urlData' of undefined`, while `focus.util.url.builder('route', 'method')({})`.
It would be better to be able to call a route without any data object.
