### PR TITLE
Feature npm include

### DIFF
--- a/.npminclude
+++ b/.npminclude
@@ -1,0 +1,2 @@
+dist
+lib

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-core",
-  "version": "0.11.0-beta",
+  "version": "0.11.0-beta-1",
   "description": "Focus library core part.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
- Add a `.npminclude` to always publish `lib` and `dist`
