### PR TITLE
Fix error server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-core",
-  "version": "0.11.4-beta1",
+  "version": "0.11.4-beta2",
   "description": "Focus library core part.",
   "main": "lib/index.js",
   "directories": {

--- a/src/application/action-builder.js
+++ b/src/application/action-builder.js
@@ -52,7 +52,7 @@ function _dispatchServiceResponse({node, type, status, callerId}, json){
  */
 function _dispatchFieldErrors({node, callerId}, errorResult){
     const isMultiNode = isArray(node);
-    const data = errorResult || {[node] : null};
+    const data = isMultiNode ? errorResult : {[node]: errorResult};
     const errorStatus = {
         name: 'error',
         isLoading: false


### PR DESCRIPTION
# Fix server error
## Description

When an error came from the server it contains all the fields in an object. The action builder didn't wrap them in a `nodeName` property. 

Fixes https://github.com/KleeGroup/focus-components/issues/587
