### PR TITLE
[action builder] fix #223

### DIFF
--- a/src/application/action-builder.js
+++ b/src/application/action-builder.js
@@ -109,8 +109,12 @@ module.exports = function actionBuilder(config = {}){
     if(!config.node){
         throw new Error('You shoud specify the store node name impacted by the action');
     }
-    return function actionBuilderFn(payload) {
-        const conf = {callerId: this._identifier, postService: identity, ...config};
+    return function actionBuilderFn(payload, context) {
+        context = context || this;
+        const conf = {
+            callerId: context._identifier,
+            postService: identity, ...config
+        };
         const {postService} = conf;
         _preServiceCall(conf, payload);
         return conf.service(payload).then(postService).then((jsonData)=>{


### PR DESCRIPTION
# Fix action builder context

The action builder now has context `actionBuilderFn(payload, context)` in order to be able to provide context to the action instead of binding it.

``` javascript
const context ={this.identifier}; 
//before
actionBuilderFn(payload).bind(context )
//or
actionBuilderFn.call(context , payload)

// now
actionBuilderFn(payload, context )
```

Fixes #223 
