### PR TITLE
remove deprecated call to react unmountComponentAtNode

### DIFF
--- a/src/application/clear.js
+++ b/src/application/clear.js
@@ -1,4 +1,4 @@
-const React = require('react');
+const ReactDOM = require('react-dom');
 let mountedComponents = require('./mounted-components');
 
 /**
@@ -7,7 +7,7 @@ let mountedComponents = require('./mounted-components');
  */
 module.exports = function clearComponent(targetSelector) {
     if(mountedComponents[targetSelector]){
-        React.unmountComponentAtNode(document.querySelector(targetSelector));
+        ReactDOM.unmountComponentAtNode(document.querySelector(targetSelector));
         delete mountedComponents[targetSelector];
         console.info('Component ' + targetSelector + ' unmounted.');
     }


### PR DESCRIPTION
# [clear] deprecated call to react unmountComponentAtNode
## Issue Description

Correction of console Warning : `call to deprecated react method unmountComponentAtNode`

![image](https://cloud.githubusercontent.com/assets/5349745/11443096/7f244364-951a-11e5-9d43-df27aa62d45a.png)

> Fixes #246
