### PR TITLE
[confirm] Add confirm function in application.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-core",
-  "version": "0.12.1-rc1",
+  "version": "0.12.1-rc2",
   "description": "Focus library core part.",
   "main": "lib/index.js",
   "directories": {

--- a/src/application/confirm.js
+++ b/src/application/confirm.js
@@ -1,0 +1,37 @@
+import {handleViewAction as dispatch} from '../dispatcher';
+
+/**
+ * This function aims to have the same behaviour as JS confirm.
+ * @param  {string | numver | component} ContentComponent - The component to display in the conform message.
+ * @return {Promise}Confirm is a promise in order to be able to provide success and error callbacks.
+ */
+export default function confirm(ContentComponent){
+    return new Promise((resolve, reject) => {
+        dispatch({
+            data: {
+                confirmConfig:{
+                    isVisible: true,
+                    ConfirmContentComponent: ContentComponent,
+                    handleCancel(data){
+                        dispatch({data: {confirmConfig: {isVsible: false}}, type: 'update'});
+                        //Maybe there is a little async problem.
+                        // We could listen to the store once on the change it is time to call resolve.
+                        resolve(data);
+                    },
+                    handleConfirm(err){
+                        dispatch({data: {confirmConfig: {isVsible: false}}, type: 'update'});
+                        reject(err);
+                    }
+                }
+            },
+            type: 'update'
+        });
+    });
+}
+
+
+//Example call
+///**
+/// confirm('Is it good for you ?').then(() => action.save()).catch(() => displaySave())
+/// confirm(MyAwesomeComponentWhichWillBeRenderAsCOntent).then(() => action.save()).catch(() => displaySave())
+////

--- a/src/application/index.js
+++ b/src/application/index.js
@@ -1,5 +1,6 @@
 const React = require('react');
 const dispatcher = require('../dispatcher');
+import confirm from './confirm';
 //Empty compoennt.
 const Empty = React.createClass({
     /** @inheritdoc */
@@ -46,5 +47,6 @@ module.exports = {
             },
             type: 'update'
         });
-    }
+    },
+    confirm
 };


### PR DESCRIPTION
## Description
- Add a confirm function helper in `focuc-core/application/confirm`
- Is is a promise, you can specify ok and cancel functions
- The `ConfirmWrapper` of focus components must be in your layout in order to see the confirm.
## Example

``` javascript
//Example call
///**
/// confirm('Is it good for you ?').then(() => action.save()).catch(() => displaySave())
/// confirm(MyAwesomeComponentWhichWillBeRenderAsCOntent).then(() => action.save()).catch(() => displaySave())
////
```

Related to https://github.com/KleeGroup/focus-components/pull/785
Also to https://github.com/KleeGroup/focus-components/issues/778
