### PR TITLE
[fetch] Add custom headers configuration

### DIFF
--- a/src/network/cors.js
+++ b/src/network/cors.js
@@ -1,45 +1,49 @@
-"use strict";
 /*global XMLHttpRequest, XDomainRequest*/
 /**
- * Error.
- * @type {Error}
- */
-var ArgumentInvalidException = Error;
+* Error.
+* @type {Error}
+*/
+
+import {map} from 'lodash/collection';
+
+const ArgumentInvalidException = Error;
 
 /**
- * Create a cors http request.
- * @param {string} method - Type of method yopu want to reach.
- * @param {string} url - Url to reach.
- * @param {object} options - The cors options.
- * @returns {XMLHttpRequest} - The CORS http request.
- */
+* Create a cors http request.
+* @param {string} method - Type of method yopu want to reach.
+* @param {string} url - Url to reach.
+* @param {object} options - The cors options.
+* @returns {XMLHttpRequest} - The CORS http request.
+*/
 module.exports = function createCORSRequest(method, url, options = {}) {
-  const isCORS = options.isCORS || false;
-  if (typeof method !== "string") {
-    throw new ArgumentInvalidException('The method should be a string in GET/POST/PUT/DELETE', method);
-  }
-  if (typeof url !== "string") {
-    throw new ArgumentInvalidException('The url should be a string', url);
-  }
-  var xhr = new XMLHttpRequest();
-  // xhr.overrideMimeType("application/json");
-
-  //If CORS is not needed.
-  if (!isCORS) {
-    xhr.open(method, url, true);
-  } else {
-    if ("withCredentials" in xhr) {
-      // XHR for Chrome/Firefox/Opera/Safari.
-      xhr.open(method, url, true);
-    } else if (typeof XDomainRequest !== "undefined") {
-      // XDomainRequest for IE.
-      xhr = new XDomainRequest();
-      xhr.open(method, url);
-    } else {
-      // CORS not supported.
-      xhr = null;
+    const isCORS = options.isCORS || false;
+    if (typeof method !== 'string') {
+        throw new ArgumentInvalidException('The method should be a string in GET/POST/PUT/DELETE', method);
     }
-  }
-  xhr.setRequestHeader("Content-Type", "application/json");
-  return xhr;
+    if (typeof url !== 'string') {
+        throw new ArgumentInvalidException('The url should be a string', url);
+    }
+    let xhr = new XMLHttpRequest();
+    // xhr.overrideMimeType('application/json');
+
+    //If CORS is not needed.
+    if (!isCORS) {
+        xhr.open(method, url, true);
+    } else {
+        if ('withCredentials' in xhr) {
+            // XHR for Chrome/Firefox/Opera/Safari.
+            xhr.open(method, url, true);
+        } else if (typeof XDomainRequest !== 'undefined') {
+            // XDomainRequest for IE.
+            xhr = new XDomainRequest();
+            xhr.open(method, url);
+        } else {
+            // CORS not supported.
+            xhr = null;
+        }
+    }
+    map({'Content-Type': 'application/json', ...options.headers}, (value, key) => {
+        xhr.setRequestHeader(key, value);
+    });
+    return xhr;
 };

--- a/src/network/fetch.js
+++ b/src/network/fetch.js
@@ -12,7 +12,7 @@ let isObject = require('lodash/lang/isObject');
 * Create a pending status.
 * @return {object} The instanciated request status.
 */
-function createRequestStatus(){
+function createRequestStatus() {
     return {
         id: uuid(),
         status: 'pending'
@@ -23,8 +23,8 @@ function createRequestStatus(){
 * @param  {object} request - The request to treat.
 * @return {object} - The request to dispatch.
 */
-function updateRequestStatus(request){
-    if(!request || !request.id || !request.status){return; }
+function updateRequestStatus(request) {
+    if(!request || !request.id || !request.status) {return; }
     dispatcher.handleViewAction({
         data: {request: request},
         type: 'update'
@@ -36,8 +36,8 @@ function updateRequestStatus(request){
 * @param  {object} req - The requets object send back from the xhr.
 * @return {object}     - The parsed object.
 */
-function jsonParser(req){
-    if(null === req.responseText || null === req.responseText || '' === req.responseText){
+function jsonParser(req) {
+    if(null === req.responseText || null === req.responseText || '' === req.responseText) {
         console.warn('The response of your request was empty');
         return null;
     }
@@ -51,7 +51,7 @@ function jsonParser(req){
             }]
         };
     }
-    if(!isObject(parsedObject)){
+    if(!isObject(parsedObject)) {
         //Maybe this check should read the header content-type
         console.warn('The response did not sent a JSON object');
     }
@@ -67,26 +67,26 @@ function jsonParser(req){
 function fetch(obj, options = {}) {
     options.parser = options.parser || jsonParser;
     options.errorParser = options.errorParser || jsonParser;
-    let request = createCORSRequest(obj.method, obj.url, options);
-    let requestStatus = createRequestStatus();
     let config = require('./config').get();
+    let request = createCORSRequest(obj.method, obj.url, {...config, ...options});
+    let requestStatus = createRequestStatus();
     if (!request) {
         throw new Error('You cannot perform ajax request on other domains.');
     }
 
     return cancellablePromiseBuilder(function promiseFn(success, failure) {
         //Request error handler
-        request.onerror = function (error) {
+        request.onerror = error => {
             updateRequestStatus({id: requestStatus.id, status: 'error'});
             failure(error);
         };
         //Request success handler
-        request.onload = function () {
+        request.onload = () => {
             let status = request.status;
             if (status < 200 || status >= 300 ) {
                 let err = options.errorParser(request);
                 err.status = status;
-                if(config.xhrErrors[status]){
+                if(config.xhrErrors[status]) {
                     config.xhrErrors[status](request.response);
                 }
                 updateRequestStatus({id: requestStatus.id, status: 'error'});


### PR DESCRIPTION
## XHR request is sent without custom headers
### Description

It is not possible to set headers to a single or all the requests made by the core.
### Patch

Custom headers are now taken into account by the request builder.

These headers can be set globally for all the application, or individualy for a specific request.
#### Globally

At the application boot time, configure all the requests as follows :

``` js
const customHeaders = {'My first custom header': 'Its value'};
FocusCore.network.config.configure({headers: customHeaders});
```
#### Locally

When using the fetch :

``` js
fetch(myBuiltURL, {...otherOptions, headers: {'My first custom header': 'Its value'}});
```
