### PR TITLE
[Advanced-search] Search was launch 3 times

### DIFF
--- a/src/store/search/advanced-search/index.js
+++ b/src/store/search/advanced-search/index.js
@@ -1,6 +1,6 @@
 import SearchStore from '../search-store';
 
-const listenedNodes = ['query', 'scope', 'selected-facets', 'grouping-key', 'sort-by', 'sort-asc'];
+const LISTENED_NODES = ['query', 'scope', 'selected-facets', 'grouping-key', 'sort-by', 'sort-asc'];
 
 /**
  * Class standing for all advanced search information.
@@ -25,7 +25,7 @@ class AdvancedSearchStore extends SearchStore {
   }
 
   emitPendingEvents(){
-        if(this.pendingEvents.find(ev => listenedNodes.includes(ev.name.split(':change')[0]))) {
+        if(this.pendingEvents.find(ev => LISTENED_NODES.includes(ev.name.split(':change')[0]))) {
             this.emit('advanced-search-criterias:change', {status: 'update'});
         }
         this.pendingEvents.map((evtToEmit)=>{

--- a/src/store/search/advanced-search/index.js
+++ b/src/store/search/advanced-search/index.js
@@ -1,9 +1,12 @@
-let SearchStore = require('../search-store');
+import SearchStore from '../search-store';
+
+const listenedNodes = ['query', 'scope', 'selected-facets', 'grouping-key', 'sort-by', 'sort-asc'];
+
 /**
  * Class standing for all advanced search information.
  * The state should be the complete state of the page.
  */
-class AdvancedSearchStore extends SearchStore{
+class AdvancedSearchStore extends SearchStore {
   constructor(conf){
     conf = conf || {};
     conf.definition = {
@@ -20,5 +23,16 @@ class AdvancedSearchStore extends SearchStore{
     conf.identifier = 'ADVANCED_SEARCH';
     super(conf);
   }
+
+  emitPendingEvents(){
+        if(this.pendingEvents.find(ev => listenedNodes.includes(ev.name.split(':change')[0]))) {
+            this.emit('advanced-search-criterias:change', {status: 'update'});
+        }
+        this.pendingEvents.map((evtToEmit)=>{
+            let {name, data} = evtToEmit;
+            this.emit(name, data);
+        });
+    }
+
 }
 module.exports = AdvancedSearchStore;


### PR DESCRIPTION
## Issue

Advanced search was launched 3 times is some cases (when more than one criteria is changed).
## Patch

This behaviour is now corrected. Advanced search is now always launched onces, even all of criterias are launched.
# Components

Associated to : https://github.com/KleeGroup/focus-components/pull/874
