### PR TITLE
[Quick-Serch] correct event emit in quick search

### DIFF
--- a/src/store/search/advanced-search/index.js
+++ b/src/store/search/advanced-search/index.js
@@ -3,28 +3,28 @@ import SearchStore from '../search-store';
 const LISTENED_NODES = ['query', 'scope', 'selectedFacets', 'groupingKey', 'sortBy', 'sortAsc'];
 
 /**
- * Class standing for all advanced search information.
- * The state should be the complete state of the page.
- */
+* Class standing for all advanced search information.
+* The state should be the complete state of the page.
+*/
 class AdvancedSearchStore extends SearchStore {
-  constructor(conf){
-    conf = conf || {};
-    conf.definition = {
-      query: 'query',
-      scope: 'scope',
-      facets: 'facets',
-      selectedFacets: 'selectedFacets',
-      groupingKey: 'groupingKey',
-      sortBy: 'sortBy',
-      sortAsc: 'sortAsc',
-      results: 'results',
-      totalCount: 'totalCount'
-    };
-    conf.identifier = 'ADVANCED_SEARCH';
-    super(conf);
-  }
+    constructor(conf){
+        conf = conf || {};
+        conf.definition = {
+            query: 'query',
+            scope: 'scope',
+            facets: 'facets',
+            selectedFacets: 'selectedFacets',
+            groupingKey: 'groupingKey',
+            sortBy: 'sortBy',
+            sortAsc: 'sortAsc',
+            results: 'results',
+            totalCount: 'totalCount'
+        };
+        conf.identifier = 'ADVANCED_SEARCH';
+        super(conf);
+    }
 
-  emitPendingEvents(){
+    emitPendingEvents(){
         if(this.pendingEvents.find(ev => LISTENED_NODES.includes(ev.name.split(':change')[0]))) {
             this.emit('advanced-search-criterias:change', {status: 'update'});
         }

--- a/src/store/search/quick-search/index.js
+++ b/src/store/search/quick-search/index.js
@@ -1,20 +1,34 @@
 let SearchStore = require('../search-store');
+
+const LISTENED_NODES = ['query', 'scope'];
+
 /**
- * Class standing for all advanced search information.
- * The state should be the complete state of the page.
- */
+* Class standing for all advanced search information.
+* The state should be the complete state of the page.
+*/
 class QuickSearchStore extends SearchStore{
-  constructor(conf){
-    conf = conf || {};
-    conf.definition = {
-      query: 'query',
-      scope: 'scope',
-      results: 'results',
-      facets: 'facets',
-      totalCount: 'totalCount'
-    };
-    conf.identifier = 'QUICK_SEARCH';
-    super(conf);
-  }
+    constructor(conf){
+        conf = conf || {};
+        conf.definition = {
+            query: 'query',
+            scope: 'scope',
+            results: 'results',
+            facets: 'facets',
+            totalCount: 'totalCount'
+        };
+        conf.identifier = 'QUICK_SEARCH';
+        super(conf);
+    }
+
+    emitPendingEvents(){
+        if(this.pendingEvents.find(ev => LISTENED_NODES.includes(ev.name.split(':change')[0]))) {
+            this.emit('quick-search-criterias:change', {status: 'update'});
+        }
+        this.pendingEvents.map((evtToEmit)=>{
+            let {name, data} = evtToEmit;
+            this.emit(name, data);
+        });
+    }
+
 }
 module.exports = QuickSearchStore;


### PR DESCRIPTION
## Issue

Quick search was launched 3 times is some cases (when more than one criteria is changed).
## Patch

This behaviour is now corrected. Quick search is now always launched onces, even all of criterias are launched.
## Focus-components

Associated to : https://github.com/KleeGroup/focus-components/pull/891
