### PR TITLE
Expose backbone methods

### DIFF
--- a/src/history/index.js
+++ b/src/history/index.js
@@ -1,0 +1,3 @@
+import Backbone from 'backbone';
+
+export default Backbone.history;

--- a/src/history/index.js
+++ b/src/history/index.js
@@ -1,3 +1,3 @@
-import Backbone from 'backbone';
+import {history} from 'backbone';
 
-export default Backbone.history;
+export default history;

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ console.log(
 */
 module.exports = {
     application: require('./application'),
+    history: require('./history'),
     component: require('./component'),
     definition: require('./definition'),
     dispatcher: require('./dispatcher'),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,5 +1,5 @@
 var render = require('../application/render');
-var Backbone = require('backbone');
+import Backbone from 'backbone';
 var ArgumentNullException = require('../exception/argument-null-exception');
 var message = require('../message');
 var userHelper = require('../user');

--- a/src/site-description/builder.js
+++ b/src/site-description/builder.js
@@ -1,6 +1,6 @@
 let {find, some} = require('lodash/collection');
 let clone = require('lodash/lang/clone');
-let Backbone = require('backbone');
+import Backbone from 'backbone';
 
 let userHelper = require('../user');
 let siteDescriptionReader = require('./reader');


### PR DESCRIPTION
## Expose backbone methods

No longer need to use Backbone as a dependency.
`Backbone.history` is now exposed by `FocusCore.history`.
