### PR TITLE
list/load-action: infinite loop when no data returned

### DIFF
--- a/src/list/load-action/parser.js
+++ b/src/list/load-action/parser.js
@@ -5,6 +5,9 @@ module.exports = (data, context) => {
     if(context.isScroll){
         dataList = [...context.dataList, ...data.dataList];
     }
+    if ((dataList.length === 0) && (totalCount > 0)){
+        throw new Error('totalCount must be equal to zero when no data are returned!!');
+    }
     return ({
         dataList: dataList,
         totalCount: totalCount,


### PR DESCRIPTION
## [list/load-action]  Issue fix:  infinite loop when no data returned
## Issue Description

When no data returned and totalCount > 0, the scroll action emits change events in an infinite loop.
## Patch

in this case, an error is thrown 
src/list/load-action/parser.js 

``` jsx
 if ((dataList.length === 0) && (totalCount > 0)){
        throw new Error('totalCount must be equal to zero when no data are returned!!');
    }
```
