### PR TITLE
Patch facet label (2nd try)

### DIFF
--- a/src/search/search-action/parser.js
+++ b/src/search/search-action/parser.js
@@ -1,15 +1,25 @@
 //Requirements
 
-let keys = require('lodash/object/keys');
+const keys = require('lodash/object/keys');
+const isObject = require('lodash/lang/isObject');
 
 let _parseFacets = (facets) => {
     return keys(facets).reduce((formattedFacets, serverFacetKey) => {
         let serverFacetData = facets[serverFacetKey];
         formattedFacets[serverFacetKey] = keys(serverFacetData).reduce((facetData, serverFacetItemKey) => {
             let serverFacetItemValue = serverFacetData[serverFacetItemKey];
-            facetData[serverFacetItemKey] = {
-                label: serverFacetItemKey,
-                count: serverFacetItemValue
+            
+			/* Case {key: count}*/
+			let key = serverFacetItemKey;
+            let label = serverFacetItemKey;
+            let count = serverFacetItemValue;
+            if(isObject(serverFacetItemValue) && serverFacetItemValue.hasOwnProperty('label')){
+                /* Case {key: {label: label, count: count}}*/
+				({label, count} = serverFacetItemValue);
+            }			
+            facetData[key] = {
+                label,
+                count
             };
             return facetData;
         }, {});

--- a/src/search/search-action/parser.js
+++ b/src/search/search-action/parser.js
@@ -9,13 +9,13 @@ let _parseFacets = (facets) => {
         formattedFacets[serverFacetKey] = keys(serverFacetData).reduce((facetData, serverFacetItemKey) => {
             let serverFacetItemValue = serverFacetData[serverFacetItemKey];
             
-			/* Case {key: count}*/
-			let key = serverFacetItemKey;
+            /* Case {key: count}*/
+            let key = serverFacetItemKey;
             let label = serverFacetItemKey;
             let count = serverFacetItemValue;
             if(isObject(serverFacetItemValue) && serverFacetItemValue.hasOwnProperty('label')){
                 /* Case {key: {label: label, count: count}}*/
-				({label, count} = serverFacetItemValue);
+                ({label, count} = serverFacetItemValue);
             }			
             facetData[key] = {
                 label,


### PR DESCRIPTION
# Facet item label
## Description

Add the possibility for the search service to return for each facet item an `id` _and_ and a `label`.
## Fix

Update facet parser to handle two facet contracts

Previously existing contract :

``` javascript
{
    facets: {
        'FCT_PEOPLE_GENDER': {
            'f': 200,
            'm': 275
        }
    }
}
```

New contract, that allows to specify a facet item label, different from the facet item key.

``` javascript
{
    facets: {
        'FCT_PEOPLE_GENDER': {
            'f': {
                count: 200,
                label: 'Women'
            },
            'm': { 
                count: 275,
                label: 'Men'
            }
        },
    }
}
```

Fixes #271
