### PR TITLE
[seach-action] Add some adaptations to facet parser to be vertigo 9.1 compliant

### DIFF
--- a/src/search/search-action/builder.js
+++ b/src/search/search-action/builder.js
@@ -16,7 +16,7 @@ import mapValues from 'lodash/object/mapValues';
  * @return {[type]}        [description]
  */
 const _buildFacets = facets => {
-    return mapValues(facets, (facetData) => {
+    return mapValues(facets, facetData => {
         return facetData.key;
     });
 };
@@ -29,7 +29,7 @@ const _buildFacets = facets => {
 const _buildOrderAndSort = sortConf => {
     return {
       sortFieldName: sortConf.sortBy,
-      sortDesc: sortConf.sortAsc===undefined?false:!sortConf.sortAsc
+      sortDesc: sortConf.sortAsc === undefined?false:!sortConf.sortAsc
     }
 };
 

--- a/src/search/search-action/builder.js
+++ b/src/search/search-action/builder.js
@@ -15,7 +15,7 @@ import mapValues from 'lodash/object/mapValues';
  * @param  {[type]} facets [description]
  * @return {[type]}        [description]
  */
-const _buildFacets = (facets) => {
+const _buildFacets = facets => {
     return mapValues(facets, (facetData) => {
         return facetData.key;
     });
@@ -26,7 +26,7 @@ const _buildFacets = (facets) => {
  * @param  {object} sortConf - The sort configuration.
  * @return {object} - The builded sort configuration.
  */
-const _buildOrderAndSort = (sortConf) => {
+const _buildOrderAndSort = sortConf => {
     return {
       sortFieldName: sortConf.sortBy,
       sortDesc: sortConf.sortAsc===undefined?false:!sortConf.sortAsc
@@ -35,7 +35,7 @@ const _buildOrderAndSort = (sortConf) => {
 
 
 
-const _buildPagination = (opts) => {
+const _buildPagination = opts => {
     const resultsKeys = keys(opts.results);
     if(opts.isScroll && resultsKeys.length === 1){
       const key = resultsKeys[0];

--- a/src/search/search-action/builder.js
+++ b/src/search/search-action/builder.js
@@ -1,11 +1,23 @@
-let keys = require('lodash/object/keys');
-let _buildFacets = (facets) => {
-    return keys(facets).map((selectedFacetKey) => {
-        let selectedFacet = facets[selectedFacetKey];
-        return {
-            key: selectedFacetKey,
-            value: selectedFacet.key
-        };
+import keys from 'lodash/object/keys';
+import mapValues from 'lodash/object/mapValues';
+
+/**
+ * Build facets for server expected format.
+ *
+ * Expected format :
+ * -----------------
+ * {
+ * 	  "criteria": "*",
+ *   "facets": {FCT_MOVIE_TYPE: "Télefilm", FCT_MOVIE_TITLE: "g-m"}
+ * }
+ *
+ *
+ * @param  {[type]} facets [description]
+ * @return {[type]}        [description]
+ */
+const _buildFacets = (facets) => {
+    return mapValues(facets, (facetData) => {
+        return facetData.key;
     });
 };
 
@@ -14,7 +26,7 @@ let _buildFacets = (facets) => {
  * @param  {object} sortConf - The sort configuration.
  * @return {object} - The builded sort configuration.
  */
-let _buildOrderAndSort = (sortConf) => {
+const _buildOrderAndSort = (sortConf) => {
     return {
       sortFieldName: sortConf.sortBy,
       sortDesc: sortConf.sortAsc===undefined?false:!sortConf.sortAsc
@@ -23,11 +35,11 @@ let _buildOrderAndSort = (sortConf) => {
 
 
 
-let _buildPagination = (opts) => {
-    let resultsKeys = keys(opts.results);
+const _buildPagination = (opts) => {
+    const resultsKeys = keys(opts.results);
     if(opts.isScroll && resultsKeys.length === 1){
-      let key = resultsKeys[0];
-      let previousRes = opts.results[key];
+      const key = resultsKeys[0];
+      const previousRes = opts.results[key];
       if(previousRes.length < opts.totalCount){
         return {
           top: opts.nbSearchElement,
@@ -43,6 +55,8 @@ let _buildPagination = (opts) => {
       }
     }
 };
+
+
 module.exports = {
   pagination: _buildPagination,
   orderAndSort: _buildOrderAndSort,

--- a/src/search/search-action/index.js
+++ b/src/search/search-action/index.js
@@ -28,11 +28,11 @@ module.exports = function searchActionBuilder(config){
     };
 
     /**
-     * Method call when there is an error.
-     * @param  {object} config -  The action builder configuration.
-     * @param  {object} err    - The error from the API call.
-     * @return {object}     - The data from the manageResponseErrors function.
-     */
+    * Method call when there is an error.
+    * @param  {object} config -  The action builder configuration.
+    * @param  {object} err    - The error from the API call.
+    * @return {object}     - The data from the manageResponseErrors function.
+    */
     function _errorOnCall(err){
         manageResponseErrors(err, config);
         //_dispatchGlobalError shoud be separated.
@@ -41,6 +41,14 @@ module.exports = function searchActionBuilder(config){
 
     /**
     * Build search action.
+    *
+    * Expected server data format :
+    * -----------------------------
+    * {
+    * 	"criteria": "*",
+    *  	"facets": {FCT_MOVIE_TYPE: "Télefilm", FCT_MOVIE_TITLE: "g-m"}
+    * }
+    *
     * @param  {Boolean} isScroll - Is the action result from a scrolling.
     */
     return function searchAction(isScroll){
@@ -66,8 +74,8 @@ module.exports = function searchActionBuilder(config){
         //Build body data.
         const postData = {
             ...otherProps,
-            criteria: {scope, query},
-            facets: selectedFacets ? _builder.facets(selectedFacets) : [],
+            criteria: {query, scope},
+            facets: selectedFacets ? _builder.facets(selectedFacets) : {},
             group: groupingKey || ''
         };
         //Different call depending on the scope.

--- a/src/search/search-action/parser.js
+++ b/src/search/search-action/parser.js
@@ -1,22 +1,81 @@
-//Requirements
+import keys from 'lodash/object/keys';
 
-let keys = require('lodash/object/keys');
-
-let _parseFacets = (facets) => {
-    return keys(facets).reduce((formattedFacets, serverFacetKey) => {
-        let serverFacetData = facets[serverFacetKey];
-        formattedFacets[serverFacetKey] = keys(serverFacetData).reduce((facetData, serverFacetItemKey) => {
-            let serverFacetItemValue = serverFacetData[serverFacetItemKey];
-            facetData[serverFacetItemKey] = {
-                label: serverFacetItemKey,
-                count: serverFacetItemValue
+/**
+* Parse server search result to build facet results.
+* @param  {array[object]} facets server side facets results
+* @return {object} object with facets as properties
+*
+* expected facet format :
+* ------------------------
+* "facets": [
+*     {
+*        "FCT_MOVIE_TYPE": [
+*        	  {"Long-métrage": 10493},
+*            {"Télefilm": 1368},
+*            {"Court-métrage": 779},
+*            {"Moyen-métrage": 98},
+*            {"Sérials": 2},
+*            {"Film à sketches": 1}
+*        ]
+*     },
+*     {
+*       "FCT_MOVIE_TITLE": [
+*            {"#": 132},
+*            {"a-f": 3205},
+*            {"g-m": 5147},
+*            {"n-s": 2133},
+*            {"t-z": 2124}
+*       ]
+*     }
+* ]
+*
+*
+* Returned format :
+* -----------------
+* {
+* 	  FCT_MOVIE_TYPE: {
+* 	  	{
+* 	  		label: 'Long-métrage',
+*      		count: 52
+* 	     }, {
+*        	label: 'court-métrage',
+* 	  	    count: 12
+* 	     }
+*    },
+*    FCT_MOVIE_YEAR: {
+*    	 {
+*    	 	label: '1990-2000',
+*    	 	count: 8
+*    	 }
+*    }
+* }
+*
+*/
+const _parseFacets = (serverFacets) => {
+    return keys(serverFacets).reduce((formattedFacets, serverFacetKey) => {
+        //read facet keys
+        const serverFacet = serverFacets[serverFacetKey];
+        const serverFacetPopertyNames = keys(serverFacet);
+        const facetName = serverFacetPopertyNames[0];
+        const serverFacetData = serverFacet[facetName];
+        formattedFacets[facetName] = keys(serverFacetData).reduce((facetData, serverFacetItemKey) => {
+            //read facet values
+            const serverFacetItem = serverFacetData[serverFacetItemKey];
+            const serverFacetItemPopertyNames = keys(serverFacetItem);
+            const facetItemName = serverFacetItemPopertyNames[0];
+            const facetItemValue = serverFacetItem[facetItemName];
+            facetData[facetItemName] = {
+                label: facetItemName,
+                count: facetItemValue
             };
             return facetData;
         }, {});
         return formattedFacets;
     }, {});
 };
-let _parseUnscopedResponse = (data) => {
+
+
+const _parseUnscopedResponse = (data) => {
     return ({
         results: data.groups,
         facets: _parseFacets(data.facets),
@@ -24,13 +83,14 @@ let _parseUnscopedResponse = (data) => {
     });
 };
 
-let _parseScopedResponse = (data, context) => {
+
+const _parseScopedResponse = (data, context) => {
     //Scroll can only happen when there is an ungroupSearch
     if(context.isScroll){
-      let resultsKeys = keys(context.results);
-      let key = resultsKeys[0];
-      //Concat previous data with incoming data.
-      data.list = [...context.results[key], ...data.list];
+        let resultsKeys = keys(context.results);
+        let key = resultsKeys[0];
+        //Concat previous data with incoming data.
+        data.list = [...context.results[key], ...data.list];
     }
     return ({
         results: data.groups || {[context.scope]: data.list},
@@ -38,7 +98,9 @@ let _parseScopedResponse = (data, context) => {
         totalCount: data.totalCount
     });
 };
+
+
 module.exports = {
-  unscopedResponse: _parseUnscopedResponse,
-  scopedResponse: _parseScopedResponse
+    unscopedResponse: _parseUnscopedResponse,
+    scopedResponse: _parseScopedResponse
 };


### PR DESCRIPTION
### Description

Data served by vertigo search has changed since version 9.1.
Facet parser was not compliant to this new version.
### Patch [in case of a fix]

FOCUS took these changes into account, following this new API: https://github.com/KleeGroup/focus-core/wiki/Search-example
