### PR TITLE
[Formatter] add language definition for numbers

### DIFF
--- a/src/definition/formatter/number.js
+++ b/src/definition/formatter/number.js
@@ -1,16 +1,23 @@
-const numeral = require('numeral');
+import numeral from 'numeral';
 
 const DEFAULT_FORMAT = '0,0';
 
-module.exports = {
+//TODO change numeral lib and regroup initializers
+export function language(key, conf) {
+    return numeral.language(key, conf);
+};
+
+export default {
+
     /**
-     * Format a number using a given format.
-     * @param  {number} number - The number to format.
-     * @param  {string} format - The format to transform.
-     * @return {string} - The formated number.
-     */
+    * Format a number using a given format.
+    * @param  {number} number - The number to format.
+    * @param  {string} format - The format to transform.
+    * @return {string} - The formated number.
+    */
     format(number, format) {
         format = format || DEFAULT_FORMAT;
         return numeral(number).format(format);
     }
+
 };


### PR DESCRIPTION
### Description

It is now possible to define languages to correctly format number for the current language.

To do so, define a specific initiliazer:

``` javascript
import {language} from 'focus-core/definition/formatter/number';
import frLanguage from 'numeral/languages/fr';

export default () => {
    console.info('|--- NUMERAL');

    // load fr language
    language('fr', frLanguage);
    console.info('   |--- Add language french');

    //define the language
    language('fr');
    console.info('   |--- Numeral correctly initialized. Current language:' + language());
}
```
