### PR TITLE
Update action-builder to accept multiple params in action call.

### DIFF
--- a/src/application/action-builder.js
+++ b/src/application/action-builder.js
@@ -111,7 +111,7 @@ module.exports = function actionBuilder(config = {}){
         throw new Error('You shoud specify the store node name impacted by the action');
     }
     return function actionBuilderFn(...payload) {
-        if (payload[payload.length - 1]._identifier) {
+        if (payload.length > 0 && payload[payload.length - 1]._identifier) {
             console.warn('Passing the context as last parameter to an action is deprecated. Use action.call(context, ...parameters) instead.');
         }
         const conf = {

--- a/src/application/action-builder.js
+++ b/src/application/action-builder.js
@@ -110,15 +110,17 @@ module.exports = function actionBuilder(config = {}){
     if(!config.node){
         throw new Error('You shoud specify the store node name impacted by the action');
     }
-    return function actionBuilderFn(payload, context) {
-        context = context || this;
+    return function actionBuilderFn(...payload) {
+        if (payload[payload.length - 1]._identifier) {
+            console.warn('Passing the context as last parameter to an action is deprecated. Use action.call(context, ...parameters) instead.');
+        }
         const conf = {
-            callerId: context._identifier,
+            callerId: this._identifier,
             postService: identity, ...config
         };
         const {postService} = conf;
-        _preServiceCall(conf, payload);
-        return conf.service(payload).then(postService).then((jsonData)=>{
+        _preServiceCall(conf, payload[0]);
+        return conf.service(...payload).then(postService).then((jsonData)=>{
             return _dispatchServiceResponse(conf, jsonData);
         }, (err) => {
             _errorOnCall(conf, err);


### PR DESCRIPTION
## New feature: Action call (from action-builder) can now take multiple parameters.
### Description

In case your service call has multiple parameters, you can now call the action that uses the service with the same signature as the service, instead of having to wrap the differents parameters in an object.
#### Before

``` jsx
action.load({param1: 1, param2: 2});
```

called behind the scenes

``` jsx
myService({param1, param2})
```
#### After

``` jsx
action.load(1, 2)
```

calls

``` jsx
myService(param1, param2)
```
### Breaking change

Before this change, the action call took 2 fixed parameters : `payload` and `context`. `context` was optional and its only use was to provide the `_identifier` property to the action, which is found on `this`. That parameter doesn't exist anymore and you should use `action.call(this, ...parameters)` instead. It was already the recommanded way to bind the context and it was already used by Focus, so it will probably change nothing for you. Anyway, there is a deprecation warning for this.
