### PR TITLE
Fix #336

### DIFF
--- a/src/application/action-builder.d.ts
+++ b/src/application/action-builder.d.ts
@@ -1,0 +1,40 @@
+export interface Service {
+    (...args: any[]): Promise<any>;
+}
+
+export interface ActionBuilderSpec<S extends Service> {
+    node: string | string[];
+    preStatus?: string;
+    service: S;
+    status: string;
+    shouldDumpStoreOnActionCall?: boolean;
+}
+
+type ActionBuilderSpecExt<S extends Service> = ActionBuilderSpec<S> & {type: string, callerId?: string};
+
+/**
+ * Action builder function. The built action dispatch the preStatus, call the service and dispatch the result from the server.
+ * @param config The action builder config
+ */
+export default function actionBuilder<S extends Service>(config: ActionBuilderSpec<S>): S
+
+/**
+ * Method call after the service call.
+ * @param config Action builder config.
+ * @param json The data return from the service call.
+ */
+export function dispatchServiceResponse({node, type, status, callerId}: ActionBuilderSpecExt<any>, response: any): void
+
+/**
+ * Method call when there is an error.
+ * @param config The action builder configuration.
+ * @param err The error from the API call.
+ */
+export function errorOnCall(config: ActionBuilderSpecExt<any>, err: {}): void
+
+/**
+ * Method call before the service.
+ * @param config The action builder config.
+ * @param payload The request payload.
+ */
+export function preServiceCall({node, preStatus, callerId, shouldDumpStoreOnActionCall}: ActionBuilderSpecExt<any>, payload: any): void

--- a/src/application/action-builder.js
+++ b/src/application/action-builder.js
@@ -115,7 +115,7 @@ export default function actionBuilder(config = {}){
             console.warn('Passing the context as last parameter to an action is deprecated. Use action.call(context, ...parameters) instead.');
         }
         const conf = {
-            callerId: this._identifier,
+            callerId: this && this._identifier,
             postService: identity, ...config
         };
         const {postService} = conf;

--- a/src/application/action-builder.js
+++ b/src/application/action-builder.js
@@ -110,15 +110,17 @@ export default function actionBuilder(config = {}){
     if(!config.node){
         throw new Error('You shoud specify the store node name impacted by the action');
     }
-    return function actionBuilderFn(payload, context) {
-        context = context || this;
+    return function actionBuilderFn(...payload) {
+        if (payload && payload.length > 0 && payload[payload.length - 1]._identifier) {
+            console.warn('Passing the context as last parameter to an action is deprecated. Use action.call(context, ...parameters) instead.');
+        }
         const conf = {
-            callerId: context._identifier,
+            callerId: this._identifier,
             postService: identity, ...config
         };
         const {postService} = conf;
-        _preServiceCall(conf, payload);
-        return conf.service(payload).then(postService).then((jsonData)=>{
+        _preServiceCall(conf, payload[0]);
+        return conf.service(...payload).then(postService).then((jsonData)=>{
             return _dispatchServiceResponse(conf, jsonData);
         }, (err) => {
             _errorOnCall(conf, err);
@@ -126,8 +128,9 @@ export default function actionBuilder(config = {}){
     };
 };
 
+
 export {
     _errorOnCall as errorOnCall,
     _dispatchServiceResponse as dispatchServiceResponse,
     _preServiceCall as preServiceCall
-    };
+};

--- a/src/application/action-builder.js
+++ b/src/application/action-builder.js
@@ -111,7 +111,7 @@ export default function actionBuilder(config = {}){
         throw new Error('You shoud specify the store node name impacted by the action');
     }
     return function actionBuilderFn(...payload) {
-        if (payload && payload.length > 0 && payload[payload.length - 1]._identifier) {
+        if (payload && payload.length > 0 && payload[payload.length - 1] && payload[payload.length - 1]._identifier) {
             console.warn('Passing the context as last parameter to an action is deprecated. Use action.call(context, ...parameters) instead.');
         }
         const conf = {

--- a/src/application/index.d.ts
+++ b/src/application/index.d.ts
@@ -11,17 +11,6 @@ export interface Action {
     identifier?: string;
 }
 
-/**
- * Action builder config parameter
- */
-export interface ActionBuilderSpec<S> {
-    node: string;
-    preStatus?: string;
-    service: S;
-    status: string;
-    shouldDumpStoreOnActionCall?: boolean;
-}
-
 export interface CartridgeComponent {
     component: React.ComponentClass<{}> | ((props: {}) => JSX.Element);
     props?: {};
@@ -54,12 +43,6 @@ export let builtInStore: ApplicationStore;
  * Contains all selectors from the mounted components
  */
 export let mountedComponent: MountedComponentSpec;
-
-/**
- * Action builder function. The built action dispatch the preStatus, call the service and dispatch the result from the server.
- * @param config The action builder config
- */
-export function actionBuilder<S>(config: ActionBuilderSpec<S>): S
 
 /**
  * Clear a React component.


### PR DESCRIPTION
From #336:
## New feature: Action call (from action-builder) can now take multiple parameters.
### Description

In case your service call has multiple parameters, you can now call the action that uses the service with the same signature as the service, instead of having to wrap the differents parameters in an object.
#### Before

``` jsx
action.load({param1: 1, param2: 2});
```

called behind the scenes

``` jsx
myService({param1, param2})
```
#### After

``` jsx
action.load(1, 2)
```

calls

``` jsx
myService(param1, param2)
```
### Breaking change

Before this change, the action call took 2 fixed parameters : `payload` and `context`. `context` was optional and its only use was to provide the `_identifier` property to the action, which is found on `this`. That parameter doesn't exist anymore and you should use `action.call(this, ...parameters)` instead. It was already the recommanded way to bind the context and it was already used by Focus, so it will probably change nothing for you. Anyway, there is a deprecation warning for this.
