### PR TITLE
Typescript definitions for focus-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "focus-core",
-    "version": "0.15.0",
+    "version": "0.15.1-beta0",
     "description": "Focus library core part.",
     "main": "index.js",
     "babel": {

--- a/scripts/babelify.js
+++ b/scripts/babelify.js
@@ -33,7 +33,7 @@ var walk = function(dir) {
 
 var filterFiles = function(files) {
     return files.filter(function(file) {
-        return (!file.match(/(example|__tests__)/) && file.match(/\.js$/));
+        return !file.match(/(example|__tests__)/) && (file.match(/\.js$/) || file.match(/\.d.ts$/));
     });
 };
 
@@ -48,13 +48,19 @@ function ensureDirectoryExistence(filePath) {
 
 var files = filterFiles(walk('./src'));
 files.forEach(function(file) {
-    babel.transformFile(file, babelOptions, function(err, result) {
-        if (err) console.error(err);
+    if (file.match(/\.d.ts$/)) {
         var newFile = file.replace('./src', '.');
         ensureDirectoryExistence(newFile);
-        fs.writeFile(newFile, result.code, function(err) {
+        fs.createReadStream(file).pipe(fs.createWriteStream(newFile));
+    } else {
+        babel.transformFile(file, babelOptions, function(err, result) {
             if (err) console.error(err);
-            console.log('Babelified ' + file);
+            var newFile = file.replace('./src', '.');
+            ensureDirectoryExistence(newFile);
+            fs.writeFile(newFile, result.code, function(err) {
+                if (err) console.error(err);
+                console.log('Babelified ' + file);
+            });
         });
-    });
+    }
 });

--- a/src/application/index.d.ts
+++ b/src/application/index.d.ts
@@ -1,0 +1,99 @@
+import {ApplicationStore} from '../store';
+
+/**
+ * Action spec
+ */
+export interface Action {
+    type: string;
+    data: {};
+    callerId?: number;
+    status?: string | number;
+    identifier?: string;
+}
+
+/**
+ * Action builder config parameter
+ */
+export interface ActionBuilderSpec<S> {
+    node: string;
+    preStatus?: string;
+    service: S;
+    status: string;
+    shouldDumpStoreOnActionCall?: boolean;
+}
+
+export interface CartridgeComponent {
+    component: React.ComponentClass<{}> | ((props: {}) => JSX.Element);
+    props?: {};
+}
+
+export interface CartridgeConfiguration {
+    barLeft?: CartridgeComponent;
+    barRight?: CartridgeComponent;
+    cartridge?: CartridgeComponent;
+    summary?: CartridgeComponent;
+    actions?: {
+        primary: {icon: string, action: (object: any) => any}[];
+        secondary: {label: string, action: (object: any) => any}[];
+    };
+}
+
+/**
+ * Describe the mountedComponent literal
+ */
+export interface MountedComponentSpec {
+    [x: string]: boolean;
+}
+
+/**
+ *  An instanciated application store.
+ */
+export let builtInStore: ApplicationStore;
+
+/**
+ * Contains all selectors from the mounted components
+ */
+export let mountedComponent: MountedComponentSpec;
+
+/**
+ * Action builder function. The built action dispatch the preStatus, call the service and dispatch the result from the server.
+ * @param config The action builder config
+ */
+export function actionBuilder<S>(config: ActionBuilderSpec<S>): S
+
+/**
+ * Clear a React component.
+ * @param targetSelector The component DOM selector
+ */
+export function clearComponent(targetSelector: string): void
+
+/**
+ * Change application mode.
+ * @param newMode       New application mode.
+ * @param previousMode  Previous mode.
+ */
+export function changeMode(newMode: string, previousMode: string): void
+
+/**
+ * Change application route (maybe not the whole route but a route's group.)
+ * @param newRoute new route name.
+ */
+export function changeRoute(newRoute: string): void
+
+/**
+ * Clear the application header.
+ */
+export function clearHeader(): void
+
+/**
+ * Sets the header.
+ */
+export function setHeader(config: CartridgeConfiguration): void
+
+/**
+ * Render a React component in a DOM selector.
+ * @param component A react component.
+ * @param selector  A selector on a DOM node.
+ * @param options   Options for the component rendering.
+ */
+export function render(component: React.ComponentClass<{}>, selector: string, options?: {}): void

--- a/src/component/index.d.ts
+++ b/src/component/index.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Component export spec
+ */
+export interface ComponentMixin {
+    mixin: React.Component<{}, {}>;
+    component?: React.Component<{}, {}>;
+}
+
+/**
+ * Build a module with a mixin and a React component.
+ * @param componentMixin    Mixin of the component.
+ * @param isMixinOnly       If true, won't output a component
+ */
+export function builder(componentMixin: React.Component<{}, {}>, isMixinOnly?: boolean): ComponentMixin
+
+/**
+ * Expose a React type validation for the component properties validation.
+ * @param type          String or array of the types to use.
+ * @param isRequired    Defines if the props is mandatory.
+ */
+export function types(type: string | string[], isRequired?: boolean): React.Requireable<any>

--- a/src/definition/domain/container.d.ts
+++ b/src/definition/domain/container.d.ts
@@ -1,0 +1,24 @@
+import {Domain} from './index';
+
+/**
+ * Get a domain given a name.
+ * @param domainName name of the domain.
+ */
+export function get(domainName: string): {toJS(): Domain}
+
+/**
+ * Get all domains in a js {}.
+ */
+export function getAll(): {[x: string]: Domain}
+
+/**
+ * Set a domain.
+ * @param domain {} structure of the domain.
+ */
+export function set(domain: Domain): void
+
+/**
+ * Set new domains.
+ * @param newDomains New domains to add.
+ */
+export function setAll(newDomains: {[x: string]: Domain}): void

--- a/src/definition/domain/index.d.ts
+++ b/src/definition/domain/index.d.ts
@@ -1,0 +1,16 @@
+export interface Domain {
+    formatter?: (value: any) => string;
+    unformatter?: (text: string) => any;
+    locale?: string;
+    format?: string;
+    type: string;
+    validator?: (value: any) => boolean;
+    listName?: string;
+    FieldComponent?: React.ComponentClass<{}>;
+    InputLabelComponent?: React.ComponentClass<{}>;
+    InputComponent?: React.ComponentClass<{}>;
+    SelectComponent?: React.ComponentClass<{}>;
+    TextComponent?: React.ComponentClass<{}>;
+    DisplayComponent?: React.ComponentClass<{}>;
+    options?: {};
+}

--- a/src/definition/entity/builder.d.ts
+++ b/src/definition/entity/builder.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Get the entity information from the entity name and given the extended informations.
+ * @param entityName                The name of the entity.
+ * @param complementaryInformation  Additional information on the entity.
+ */
+export function getEntityInformations(entityName: string, complementaryInformation: {}): {}
+
+/**
+ * Get the field informations.
+ * @param fieldName                 Name or path of the field.
+ * @param complementaryInformation  Additional informations to extend the domain informations.
+ */
+export function getFieldInformations(fieldName: string, complementaryInformation: {}): void

--- a/src/definition/entity/container.d.ts
+++ b/src/definition/entity/container.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Get all entityDefinition in a JS Structure.
+ * @param nodePath                      The node path.
+ * @param extendedEntityConfiguration   The {} to extend the config.
+ */
+export function getEntityConfiguration(nodePath: string, extendedEntityConfiguration: {}): {}
+
+/**
+ * Get a field configuration given a path.
+ * @param fieldPath         The field path in the map.
+ * @param customFieldConf   The {} to extend the config.
+ */
+export function getFieldConfiguration(fieldPath: string, customFieldConf: {}): {}
+
+/**
+ * Set new entities in the map or extend existing one.
+ * @param newEntities New entities description.
+ */
+export function setEntityConfiguration(newEntities: {}): void

--- a/src/definition/entity/index.d.ts
+++ b/src/definition/entity/index.d.ts
@@ -1,0 +1,12 @@
+export interface EntityField {
+    domain: string;
+    isRequired: boolean;
+    name: string;
+}
+
+export interface Entity<T> {
+    fields: {[name: string]: EntityField};
+    moduleName: string;
+    name: string;
+    type: T;
+}

--- a/src/definition/formatter/number.d.ts
+++ b/src/definition/formatter/number.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Format a number using a given format.
+ * @param number The number to format.
+ * @param nb The format to transform.
+ */
+export function format(nb: number, format?: string): string

--- a/src/definition/validator/index.d.ts
+++ b/src/definition/validator/index.d.ts
@@ -1,0 +1,76 @@
+/**
+ * Spec for number validation options
+ */
+export interface MinMax {
+    min?: number;
+    max?: number;
+}
+
+/**
+ * Spec for string validation options
+ */
+export interface MinMaxLength {
+    minLength?: number;
+    maxLength?: number;
+}
+
+/**
+ * Spec for validation property
+ */
+export interface ValidationProperty {
+    name: string;
+    value: string;
+}
+
+/**
+ * Validator {}
+ */
+export interface Validator {
+    options: MinMax | MinMaxLength | {};
+    type: string;
+    value?: (param: any, {}) => boolean;
+}
+
+/**
+ * ValidatorStatus {}
+ */
+export interface ValidationStatus {
+    name: string;
+    value: string;
+    isValid: boolean;
+    errors: {};
+}
+
+/**
+ * Returns true is the date is valid, false otherwise.
+ * @param dateToValidate    The date to validate.
+ * @param options           The validator options.
+ */
+export function date(dateToValidate: string | Date, options: {}): boolean
+
+/**
+ * Returns true is the email is valid, false otherwise.
+ * @param dateToValidate    The email to validate.
+ */
+export function email(emailtoValidate: string): boolean
+
+/**
+ * Returns true is the number is valid, false otherwise.
+ * @param numberToValidate  The number to validate.
+ * @param options           The validator options.
+ */
+export function number(numberToValidate: number, options: MinMax): boolean
+
+/**
+ * Returns true is the string is valid, false otherwise.
+ * @param stringToTest  The number to validate.
+ * @param options       The validator options.
+ */
+export function stringLength(stringToTest: number, options: MinMaxLength): boolean
+
+/**
+ * Validate a property with given validators and returns the validation status.
+ * @param property      Property to validate.
+ * @param validators    The validators to apply on the property.
+ */
+export function validate(property: ValidationProperty, validators: Array<Validator>): ValidationStatus

--- a/src/dispatcher/index.d.ts
+++ b/src/dispatcher/index.d.ts
@@ -1,0 +1,26 @@
+import {Action} from '../application';
+
+declare class Dispatcher extends Flux.Dispatcher<any> {
+
+    // Constructor override to hide the default doc
+    constructor()
+
+    /**
+     * Dispatch an action coming from the server.
+     * @param action The action to dispatch
+     */
+    handleServerAction(action: Action): void
+
+    /**
+     * Dispatch an action coming from a view.
+     * @param action The action to dispatch
+     */
+    handleViewAction(action: Action): void
+}
+
+/**
+ * Application dispatcher
+ */
+declare let dispatcher: Dispatcher;
+
+export = dispatcher

--- a/src/exception/index.d.ts
+++ b/src/exception/index.d.ts
@@ -1,0 +1,92 @@
+/**
+ * Class standing for the ArgumentInvalid exception.
+ */
+export class ArgumentInvalidException extends CustomException {
+
+    /**
+     * Exception constructor.
+     * @param message Exception message.
+     * @param options {} to add to the exception.
+     */
+    constructor(message: string, options: {})
+}
+
+/**
+ * Class standing for the ArgumentNull exception.
+ */
+export class ArgumentNullException extends CustomException {
+
+    /**
+     * Exception constructor.
+     * @param message Exception message.
+     * @param options {} to add to the exception.
+     */
+    constructor(message: string, options: {})
+}
+
+/**
+ * Class standing for custom exception.
+ */
+export class CustomException implements Error {
+
+    // Properties
+    message: string;
+    name: string;
+
+    /**
+     * Exception constructor.
+     * @param name    Exception name.
+     * @param message Exception message.
+     * @param options {} to add to the exception.
+     */
+    constructor(name: string, message: string, options: {})
+
+    /**
+     * Log the exception in the js console.
+     */
+    log(): void
+
+    /**
+     * Jsonify the exception.
+     */
+    toJSON(): {}
+}
+
+/**
+ * Class standing for the Dependency exception.
+ */
+export class DependencyExcepton extends CustomException {
+
+    /**
+     * Exception constructor.
+     * @param message Exception message.
+     * @param options {} to add to the exception.
+     */
+    constructor(message: string, options: {})
+}
+
+/**
+ * Class standing for the Focus exception.
+ */
+export class FocusException extends CustomException {
+
+    /**
+     * Exception constructor.
+     * @param message Exception message.
+     * @param options {} to add to the exception.
+     */
+    constructor(message: string, options: {})
+}
+
+/**
+ * Class standing for the NotImplemented exception.
+ */
+export class NotImplementedException extends CustomException {
+
+    /**
+     * Exception constructor.
+     * @param message Exception message.
+     * @param options {} to add to the exception.
+     */
+    constructor(message: string, options: {})
+}

--- a/src/history/index.d.ts
+++ b/src/history/index.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Navigates to the given URL.
+ * @param path The URL to navigate to.
+ * @param options Navigation options.
+ */
+export function navigate(path: string, options?: {trigger?: boolean, replace?: boolean}): void
+
+/**
+ * Starts the router.
+ */
+export function start(): void

--- a/src/list/index.d.ts
+++ b/src/list/index.d.ts
@@ -1,0 +1,57 @@
+/**
+ * ListActionBuilder spec
+ */
+export interface ListActionBuilderSpec {
+
+    /**
+     * ListStore identifier
+     */
+    identifier: string;
+
+    /**
+     * Service
+     */
+    service: (...args: any[]) => Promise<{dataList: any[], totalCount: number}>;
+
+    /**
+     *  Function that get the associated search store value
+     */
+    getListOptions: () => {};
+
+    /**
+     * Number of elements to request on each search.
+     */
+    nbSearchElements?: number;
+}
+
+/**
+ * ListAction spec
+ */
+export interface ListAction {
+
+    load: LoadAction;
+
+    /**
+     * Update the query for the identifier scope.
+     * @param value The query parameters.
+     */
+    updateProperties(value: {}): void;
+}
+
+/**
+ * LoadAction interface
+ */
+export interface LoadAction {
+    (isScroll?: boolean): void;
+}
+
+/**
+ * Build a list action.
+ */
+export function actionBuilder(config: ListActionBuilderSpec): ListAction
+
+/**
+ * Search action generated from the config.
+ * @param config Action configuration.
+ */
+export function loadAction(config: {}): LoadAction

--- a/src/message/index.d.ts
+++ b/src/message/index.d.ts
@@ -1,0 +1,41 @@
+import {MessageStore} from '../store';
+
+/**
+ * Add a message.
+ * @param message The message content.
+ */
+export function addMessage({content}: {content: string}): void
+
+/**
+ * Add a warning message.
+ * @param message The message content.
+ */
+export function addWarningMessage(message: string | {content: string}): void
+
+/**
+ * Add an information message.
+ * @param message The message content.
+ */
+export function addInformationMessage(message: string | {content: string}): void
+
+/**
+ * Add an error message.
+ * @param message The message content.
+ */
+export function addErrorMessage(message: string | {content: string}): void
+
+/**
+ * Add a success message.
+ * @param message The message content.
+ */
+export function addSuccessMessage(message: string | {content: string}): void
+
+/**
+ * The message store
+ */
+export let builtInStore: MessageStore;
+
+/**
+ * Clear all the messages
+ */
+export function clearMessages(): void

--- a/src/network/config.d.ts
+++ b/src/network/config.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Overrides the config
+ * @param conf New config
+ */
+export function configure(conf: {}): void
+
+/**
+ * Returns the config
+ */
+export function get(): {CORS: boolean, xhrErrors: {}}

--- a/src/network/error-parsing.d.ts
+++ b/src/network/error-parsing.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Configures the error parsing module
+ * @param options The config options
+ */
+export function configure(options?: {globalMessages?: Array<any>, errorTypes?: {}}): void
+
+/**
+ * Transforms errors send by API to application errors. Dispatch depending on the response http code. Returns parsed error response.
+ * @param response  Response {} that needs to be transformed
+ * @param options   Options for the exceptions teratement such as the model, {model: modelVar}.
+ */
+export function manageResponseErrors(response: {}, options?: {}): {}

--- a/src/network/index.d.ts
+++ b/src/network/index.d.ts
@@ -1,0 +1,55 @@
+import {RequestStore} from '../store';
+
+/**
+ * FetchRequest spec
+ */
+export interface FetchRequest {
+    /**
+     * HTTP verb
+     */
+    method: string;
+
+    /**
+     * URL to fetch
+     */
+    url: string;
+
+    /**
+     * JSON data
+     */
+    data: {};
+}
+
+/**
+ * Cancellable Promise spec
+ */
+export interface CancellablePromise<T> extends Promise<T> {
+    cancel?: Function;
+}
+
+/**
+ * The built-in request store
+ */
+export let builtInStore: RequestStore;
+
+/**
+ * Create a cancellable promise {}, with an optional cancel handler function given as an argument.
+ * @param promiseFn
+ * @param cancelHandler
+ */
+export function cancellablePromiseBuilder<T>(promiseFn: Function, cancelHandler?: Function): CancellablePromise<T>
+
+/**
+ * Creates a cors http request.
+ * @param method    Type of method you want to reach.
+ * @param url       Url to reach.
+ * @param options   The cors options.
+ */
+export function cors(method: string, url: string, {}?: {}): XMLHttpRequest
+
+/**
+ * Fetch function to ease http request.
+ * @param obj       The request
+ * @param options   The options {}.
+ */
+export function fetch<T>(obj: FetchRequest, options?: {}): CancellablePromise<T>

--- a/src/reference/builder.d.ts
+++ b/src/reference/builder.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Load a list from its description
+ * @param listDesc Description of the list to load
+ */
+export function loadList(listDesc: {url: string}): Promise<any>
+
+/**
+ * Load a reference with its list name.
+ * It calls the service which must have been registered.
+ * @param listName  The name of the list to load.
+ * @param args      Argument to provide to the function.
+ */
+export function loadListByName(listName: string, args: {}): Promise<any>
+
+/**
+ * Load many lists by their names.
+ * Be careful, if there is a problem for one list, the error callback is called.
+ * @param names The list of lists to load
+ */
+export function loadMany(names: string[]): Promise<any>[]
+
+/**
+ * Get a function to trigger in autocomplete case.
+ * The function will trigger a promise.
+ * @param listName Name of the list.
+*/
+export function getAutoCompleteServiceQuery(listName: string): (query: {term: {}, callback: Function}) => Promise<any>

--- a/src/reference/config.d.ts
+++ b/src/reference/config.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Get a configuration copy.
+ */
+export function get(): {}
+
+/**
+ * Get an element from the configuration using its name.
+ * @param name The key identifier of the configuration
+ */
+export function getConfigElement(name: string): {}
+
+/**
+ * Set the reference configuration.
+ * @param newConf           The new configuration to set.
+ * @param isClearPrevious   Does the config should be reset.
+ */
+export function set(newConf: {}, isClearPrevious?: boolean): void

--- a/src/reference/index.d.ts
+++ b/src/reference/index.d.ts
@@ -1,0 +1,12 @@
+import {ReferenceStore} from '../store';
+
+/**
+ * Focus reference action.
+ * @param referenceNames An array which contains the name of all the references to load.
+ */
+export function builtInAction(referenceNames: string[]): () => Promise<any>
+
+/**
+ * Builds a new reference store
+ */
+export function storeGetter(): ReferenceStore

--- a/src/router/index.d.ts
+++ b/src/router/index.d.ts
@@ -1,0 +1,12 @@
+interface RouterConfig {
+    log?: boolean;
+    beforeRoute?: () => void;
+    routes: {[x: string]: string};
+}
+
+declare let router: {
+    extend<T>(config: T & RouterConfig): {new(): {}}
+};
+
+export = router
+

--- a/src/search/built-in-store.d.ts
+++ b/src/search/built-in-store.d.ts
@@ -1,0 +1,4 @@
+import {QuickSearch, AdvancedSearch} from '../store/search';
+
+export let quickSearchStore: QuickSearch;
+export let advancedSearchStore: AdvancedSearch;

--- a/src/search/index.d.ts
+++ b/src/search/index.d.ts
@@ -1,0 +1,55 @@
+/**
+ * SearchActionBuilder spec
+ */
+export interface SearchActionBuilderSpec {
+
+    /**
+     * SearchStore identifier
+     */
+    identifier: string;
+
+    /**
+     * Service
+     */
+    service: {
+        scoped: (...args: any[]) => Promise<any>;
+        unscoped: (...args: any[]) => Promise<any>;
+    };
+
+    /**
+     *  Function that get the associated search store value
+     */
+    getSearchOptions: () => {};
+
+    /**
+     * Number of elements to request on each search.
+     */
+    nbSearchElements?: number;
+}
+
+/**
+ * SearchAction spec
+ */
+export interface SearchAction {
+
+    search: LoadSearchAction;
+
+    /**
+     * Update the query for the identifier scope.
+     * @param value The query parameters.
+     */
+    updateProperties(value: {[x: string]: any}): void;
+}
+
+/**
+ * LoadAction interface
+ */
+export interface LoadSearchAction {
+    (isScroll?: boolean): void;
+}
+
+/**
+ * Builds a search action and returns it.
+ * @param config The options used to build the service.
+ */
+export function actionBuilder(config: SearchActionBuilderSpec): SearchAction

--- a/src/site-description/builder.d.ts
+++ b/src/site-description/builder.d.ts
@@ -1,0 +1,45 @@
+import {SiteDescription} from './index';
+
+/**
+ * Find a route with its name and returns it.
+ * @param routeToTest Route to test.
+ */
+export function findRouteName(routeToTest: string): string
+
+/**
+ * Gets the specified route.
+ * @param routeName The name of the route.
+ */
+export function getRoute(routeName: string): string
+
+/**
+ * Gets all the application routes from the siteDescription.
+ */
+export function getRoutes(): string[]
+
+/**
+ * Gets the site description.
+ */
+export function getSiteDescription(): SiteDescription
+
+/**
+ * Gets the site structure.
+ */
+export function getSiteStructure(): {}
+
+/**
+ * Processes the siteDescription if necessary.
+ * @param options The options.
+ */
+export function processSiteDescription(options: {isForceProcess?: any}): {} | boolean
+
+/**
+ * Regenerates the application routes.
+ */
+export function regenerateRoutes(): void
+
+/**
+ * Gets the RegExp associated with the route.
+ * @param route The route.
+ */
+export function routeToRegExp(route: string): RegExp

--- a/src/site-description/index.d.ts
+++ b/src/site-description/index.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Site Description interface. Probably incomplete.
+ */
+interface SiteDescription {
+    value: Function;
+    params: {};
+}
+
+/**
+ * Gets the site structure processed with the user roles.
+ */
+export function getUserSiteStructure(): {}

--- a/src/site-description/reader.d.ts
+++ b/src/site-description/reader.d.ts
@@ -1,0 +1,31 @@
+import {SiteDescription} from './index';
+
+/**
+ * Checks if the params is define in the params list.
+ * @param paramsArray The parameter array.
+ */
+export function checkParams(paramsArray: any[]): boolean
+
+/**
+ * Defines a parameter.
+ * @param param The parameter to define.
+ */
+export function defineParam(param: {name: string, value: any}): boolean
+
+/**
+ * Defines the application site description.
+ * @param siteDescription The application site description.
+ */
+export function defineSite(siteDescription: SiteDescription): {}
+
+/**
+ * Gets the site description parameters.
+ */
+export function getParams(): {}
+
+/**
+ * Gets the site process.
+ */
+export function getSite(): {}
+
+export function isProcessed(): boolean

--- a/src/store/index.d.ts
+++ b/src/store/index.d.ts
@@ -1,0 +1,286 @@
+/**
+ *  Class standing for the cartridge store.
+ */
+export class ApplicationStore extends CoreStore<{route: string, mode: string, canDeploy: boolean}> {
+
+    /**
+     * Constructor of the store class.
+     * @param config The store config.
+     */
+    constructor(config: {definition: {}})
+
+    /**
+     * Update the mode value.
+     * @param dataNode The value of the data.
+     */
+    updateMode(dataNode: {}): void
+}
+
+/**
+ * Base class for all stores
+ */
+export class CoreStore<T> implements NodeJS.EventEmitter {
+
+    /**
+     * Getter on the definition property.
+     */
+    definition: T;
+
+    /**
+     * Getter on the identifier property.
+     */
+    identifier: string;
+
+    /**
+     * Constructor of the store class.
+     * @param config The store config.
+     */
+    constructor(config: {definition: T});
+
+    /**
+     * Add a listener on a store event.
+     * @param eventName Event name.
+     * @param cb        CallBack to call on the event change name.
+     */
+    addListener(eventName: string, cb: Function): this
+
+    /**
+     * Initialize the store configuration.
+     */
+    buildDefinition(): {}
+
+    /**
+     * Build a change listener for each property in the definition. (should be macro entities).
+     */
+    buildEachNodeChangeEventListener(): void
+
+    /**
+     * Clear all pending events.
+     */
+    clearPendingEvents(): void
+
+    /**
+     * Delay all the change emit by the store to be sure it is done after the internal store propagation and to go out of the dispatch function.
+     */
+    delayPendingEvents(context: CoreStore<T>): void
+
+    /**
+     * Emit all events pending in the pendingEvents map.
+     */
+    emitPendingEvents(): void
+
+    /**
+     * Returns the status of a definition.
+     * @param The definition to load.
+     */
+    getStatus(def: string): {isLoading: boolean}
+
+    /**
+     * Get the whole value of the store
+     */
+    getValue(): {}
+
+    /**
+     * Registers the store on the dispatcher
+     */
+    registerDispatcher(): void
+
+    /**
+     * Replace the emit function with a willEmit in order to store the changing event but send it afterwards.
+     * @param eventName The event name.
+     * @param data      The event's associated data.
+     */
+    willEmit(eventName: string, data: {}): void
+
+    // EventEmitter methods not reimplemented
+    listenerCount(type: string): number
+    getMaxListeners(): number
+    on(event: string, listener: Function): this
+    once(event: string, listener: Function): this
+    removeListener(event: string, listener: Function): this
+    removeAllListeners(event?: string): this
+    setMaxListeners(n: number): this
+    listeners(event: string): Function[]
+    emit(event: string, ...args: any[]): boolean
+}
+
+/**
+ * Class standing for all list information.
+ * The list has almost the same data as the search store but instead of the facets, it can have a ...
+ */
+export class ListStore extends CoreStore<{identifier: string}> {
+
+    /**
+     * Constructor of the store class.
+     * @param config The store config.
+     */
+    constructor(config: {identifier: string})
+}
+
+/**
+ * Class standing for the message store
+ */
+export class MessageStore extends CoreStore<{}> {
+
+    /**
+     * Add a listener on the global change on the search store.
+     * @param conf The configuration of the message store.
+     */
+    constructor(conf: {})
+
+    /**
+     * Add a listener on the global clear change on the search store.
+     * @param cb - The callback to call when a message is cleared.
+     */
+    addClearMessagesListener(cb: Function): void
+
+    /**
+     * Add a listener on the global push change on the search store.
+     * @param cb The callback to call when a message is pushed.
+     */
+    addPushedMessageListener(cb: Function): void
+
+    /**
+     * Clear all messages in the stack.
+     */
+    clearMessages(): void
+
+    /**
+     * Delete a message given its id.
+     * @param messageId The message identifier.
+     */
+    deleteMessage(messageId: number): void
+
+    /**
+     * Get a message from its identifier.
+     * @param messageId The message identifier.
+     */
+    getMessage(messageId: string): {}
+
+    /**
+     * Add a listener on the global change on the search store.
+     * @param message The message to add.
+     */
+    pushMessage(message: {}): void
+
+    /**
+     * Registers the store on the dispatcher
+     */
+    registerDispatcher(): void
+
+    /**
+     * Remove a listener on the global clear change on the search store.
+     * @param {function} cb - The callback to remove
+     */
+    removeClearMessagesListener(cb: Function): void
+
+    /**
+     * Remove a listener on the global push change on the search store.
+     * @param cb - The callback to remove
+     */
+    removePushedMessageListener(cb: Function): void
+}
+
+/**
+ * Class standing for the reference store.
+ */
+export class ReferenceStore extends CoreStore<{}> {
+
+    /**
+     * Add a listener on the global change on the search store.
+     * @param conf The configuration of the reference store.
+     */
+    constructor(conf: {})
+
+    /**
+     * Gets the list of references of the store
+     * @param names The list of references to get
+     */
+    getReference(names: string[]): {references: {}}
+
+    /**
+     * Not implemented
+     */
+    setReference(): void
+}
+
+/**
+ * Class standing for the request store
+ */
+export class RequestStore extends CoreStore<{}> {
+
+    /**
+     * Adds a listener on the global change on the request store.
+     * @param {{}} conf - The configuration of the request store.
+     */
+    constructor(conf: {})
+
+    /**
+     * Adds a listener on the global clear change on the request store.
+     * @param cb The callback to call on change
+     */
+    addClearRequestsListener(cb: Function): void
+
+    /**
+     * Adds a listener on the global update change on the request store.
+     * @param cb The callback to call on change
+     */
+    addUpdateRequestListener(cb: Function): void
+
+    /**
+     * Clears all requests in the stack.
+     */
+    clearRequests(): void
+
+    /**
+     * Gets a request from its identifier.
+     * @param requestId The request identifier.
+     */
+    getRequest(requestId: string): {}
+
+    /**
+     * Gets the requests by type
+     */
+    getRequests(): {
+        pending: number
+        cancelled: number
+        success: number
+        error: number
+        total: number
+    }
+
+    /**
+     * Removes a listener on the global clear change on the request store.
+     * @param cb The callback to call on change
+     */
+    removeClearRequestsListener(cb: Function): void
+
+    /**
+     * Removes a listener on the global update change on the request store.
+     * @param cb The callback to call on change
+     */
+    removeUpdateRequestListener(cb: Function): void
+
+    /**
+     * Registers the store on the dispatcher
+     */
+    registerDispatcher(): void
+
+    /**
+     * Updates a request
+     * @param request The request to update.
+     */
+    updateRequest(request: {}): void
+}
+
+/**
+ * Class standing for the user store
+ */
+export class UserStore extends CoreStore<{}> {
+
+    /**
+     * Adds a listener on the global change on the request store.
+     * @param conf - The configuration of the request store.
+     */
+    constructor(conf: {})
+}

--- a/src/store/search/index.d.ts
+++ b/src/store/search/index.d.ts
@@ -1,0 +1,32 @@
+import {CoreStore} from '../index';
+
+/**
+ * Base search store class (don't use)
+ */
+export class SearchStore<T> extends CoreStore<T> {
+    getValue(): {}
+}
+
+/**
+ * Class standing for all quick search information.
+ * The state should be the complete state of the page.
+ */
+export class QuickSearch extends SearchStore<{query: string, results: any[]}> {
+    /**
+     * Adds a listener on the global change on the search store.
+     * @param {{}} conf - The configuration of the request store.
+     */
+    constructor(conf?: {})
+}
+
+/**
+ * Class standing for all advanced search information.
+ * The state should be the complete state of the page.
+ */
+export class AdvancedSearch extends SearchStore<{query: string, scope: string}> {
+    /**
+     * Adds a listener on the global change on the search store.
+     * @param {{}} conf - The configuration of the request store.
+     */
+    constructor(conf: {})
+}

--- a/src/translation/index.d.ts
+++ b/src/translation/index.d.ts
@@ -1,0 +1,2 @@
+export function init({resStore, lng}: {resStore: {}, lng: string}, cb?: Function): void
+export function translate(key: string): string

--- a/src/user/index.d.ts
+++ b/src/user/index.d.ts
@@ -1,0 +1,61 @@
+import {UserStore} from '../store';
+
+export interface Login {
+    login: string;
+    password: string;
+}
+
+export interface Profile {
+    id: string;
+    provider: string;
+    displayName: string;
+    culture: string;
+    email: string;
+    photo: string;
+    firstName: string;
+    lastName: string;
+}
+
+/**
+ * The built-in userStore.
+ */
+export let builtInStore: UserStore;
+
+/**
+ * Checks if a user has the given role or roles.
+ * @param role A role or a list of roles.
+ */
+export function hasRole(role: string | string[]): boolean
+
+/**
+ * Gets the user login.
+ */
+export function getLogin(): Login
+
+/**
+ * Gets the user profile.
+ */
+export function getProfile(): Profile
+
+/**
+ * Gets the user roles.
+ */
+export function getRoles(): string[]
+
+/**
+ * Sets user profile.
+ * @param login User login.
+ */
+export function setLogin(login: Login): void
+
+/*
+ * Sets the user profile.
+ * @param profile User profile.
+ */
+export function setProfile(profile: Profile): void
+
+/**
+ * Sets the user roles.
+ * @param roles User role list.
+ */
+export function setRoles(roles: string[]): void

--- a/src/util/object/index.d.ts
+++ b/src/util/object/index.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Asserts an {} is an objet.
+ * @param name - The property name
+ * @param data - The data to validate.
+ */
+export function check(name: string, data: {}): void
+
+/**
+ * Asserts an {} is not null.
+ * @param name - The property name
+ * @param data - The data to validate.
+ */
+export function checkIsNotNull(name: string, data: {}): void

--- a/src/util/string/index.d.ts
+++ b/src/util/string/index.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Asserts an string is a string.
+ * @param name - The property name
+ * @param data - The string to validate.
+ */
+export function check(name: string, data: string): void

--- a/src/util/url/index.d.ts
+++ b/src/util/url/index.d.ts
@@ -1,0 +1,31 @@
+export interface UrlParam {
+    /**
+     * The JSON data to inject in the URL.
+     */
+    urlData: {};
+
+    /**
+     * The JSON data to give to the request.
+     */
+    data?: {};
+}
+
+export interface Url {
+    url: string;
+    method: string;
+    data: {};
+}
+
+/**
+ * Builds an url.
+ * @param url url with params such as http://url/entity/${id}.
+ * @param method HTTP verb {GET, POST, PUT, DELETE}.
+ */
+export function builder(url: string, method: string): (param: UrlParam) => Url
+
+/**
+ * Processes an url in order to build them.
+ * @param url The url.
+ * @param data The data.
+ */
+export function preprocessor(url: string, data: {}): string


### PR DESCRIPTION
This PR adds Typescript definitions files to focus-core.

There's a total of 34 definitions files, matching every module that focus-core exposes (a module contains functions, variables/constants, classes and interfaces, and **no** submodule).

They'll be picked up by the Typescript langage service by any IDE when importing a module. Of course, that means you'll need some kind of Typescript plugin (it's built in [Visual Studio Code](http://code.visualstudio.com) by the way) there.

These will provide, in regular JS, some autocompletion features, and for those using Typescript (well, that's only me right now), it will also provide typings and code validation.

![focusdts1](https://cloud.githubusercontent.com/assets/3266897/15396219/598d5cea-1ddb-11e6-88f9-064872a80e41.PNG)
![focusdts2](https://cloud.githubusercontent.com/assets/3266897/15396222/5b306aec-1ddb-11e6-9e55-68a9ea246a4f.PNG)
