### PR TITLE
Adding function to validate props with propTypes, without component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,117 +1,118 @@
 {
-    "name": "focus-core",
-    "version": "0.16.0-beta0",
-    "description": "Focus library core part.",
-    "main": "index.js",
-    "babel": {
-        "presets": [
-            "stage-0",
-            "react",
-            "es2015"
-        ],
-        "plugins": [
-            "transform-class-properties",
-            "transform-decorators-legacy",
-            "add-module-exports",
-            "transform-proto-to-assign",
-            [
-                "transform-es2015-classes",
-                {
-                    "loose": true
-                }
-            ]
-        ]
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/KleeGroup/focus-core.git"
-    },
-    "keywords": [
-        "spa",
-        "react",
-        "es6"
+  "name": "focus-core",
+  "version": "0.16.0-beta0",
+  "description": "Focus library core part.",
+  "main": "index.js",
+  "babel": {
+    "presets": [
+      "stage-0",
+      "react",
+      "es2015"
     ],
-    "author": "focus@kleegroup.com",
-    "documentation": "http://kleegroup.github.io/focus-docs/",
-    "license": "MIT",
-    "homepage": "https://github.com/KleeGroup/focus-core",
-    "bugs": {
-        "url": "https://github.com/KleeGroup/focus-core/issues"
-    },
-    "scripts": {
-        "babelify": "better-npm-run babelify",
-        "bundle": "better-npm-run bundle",
-        "test": "mocha src/**/__tests__/**/*.js",
-        "test:watch": "mocha src/**/__tests__/**/*.js -w",
-        "build": "better-npm-run babelify && better-npm-run bundle"
-    },
-    "betterScripts": {
-        "babelify": {
-            "command": "node scripts/babelify.js"
-        },
-        "bundle": {
-            "command": "webpack --progress",
-            "env": {
-                "DEV": false,
-                "NODE_ENV": "production",
-                "LIBRARY_NAME": "FocusCore",
-                "MINIMIFY": false,
-                "PACKAGE_JSON_PATH": "../"
-            }
+    "plugins": [
+      "transform-class-properties",
+      "transform-decorators-legacy",
+      "add-module-exports",
+      "transform-proto-to-assign",
+      [
+        "transform-es2015-classes",
+        {
+          "loose": true
         }
+      ]
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/KleeGroup/focus-core.git"
+  },
+  "keywords": [
+    "spa",
+    "react",
+    "es6"
+  ],
+  "author": "focus@kleegroup.com",
+  "documentation": "http://kleegroup.github.io/focus-docs/",
+  "license": "MIT",
+  "homepage": "https://github.com/KleeGroup/focus-core",
+  "bugs": {
+    "url": "https://github.com/KleeGroup/focus-core/issues"
+  },
+  "scripts": {
+    "babelify": "better-npm-run babelify",
+    "bundle": "better-npm-run bundle",
+    "test": "mocha src/**/__tests__/**/*.js",
+    "test:watch": "mocha src/**/__tests__/**/*.js -w",
+    "build": "better-npm-run babelify && better-npm-run bundle"
+  },
+  "betterScripts": {
+    "babelify": {
+      "command": "node scripts/babelify.js"
     },
-    "dependencies": {
-        "flux": "^2.0.3",
-        "i18next-client": "^1.11.4",
-        "immutable": "^3.7.3",
-        "keymirror": "^0.1.1",
-        "lodash": "^3.9.1",
-        "object-assign": "^2.0.0",
-        "uuid": "^2.0.1"
-    },
-    "devDependencies": {
-        "babel": "^6.3.26",
-        "babel-cli": "^6.4.0",
-        "babel-core": "^6.4.0",
-        "babel-eslint": "4.1.3",
-        "babel-loader": "^6.2.1",
-        "babel-plugin-add-module-exports": "^0.1.2",
-        "babel-plugin-runtime": "^1.0.7",
-        "babel-plugin-transform-class-properties": "^6.4.0",
-        "babel-plugin-transform-decorators-legacy": "^1.3.4",
-        "babel-plugin-transform-es2015-classes": "^6.5.2",
-        "babel-plugin-transform-proto-to-assign": "^6.5.0",
-        "babel-preset-es2015": "^6.3.13",
-        "babel-preset-react": "^6.3.13",
-        "babel-preset-stage-0": "^6.3.13",
-        "babel-runtime": "^6.3.19",
-        "better-npm-run": "0.0.5",
-        "chai": "^3.2.0",
-        "chai-subset": "^1.1.0",
-        "css-loader": "^0.19.0",
-        "eslint": "1.5.1",
-        "eslint-config-focus": "0.3.0",
-        "eslint-plugin-filenames": "0.1.1",
-        "eslint-plugin-react": "3.5.0",
-        "express": "^4.12.2",
-        "extract-text-webpack-plugin": "^0.8.2",
-        "file-loader": "^0.8.4",
-        "jquery": "^2.1.4",
-        "json-loader": "^0.5.3",
-        "mocha": "^2.3.2",
-        "moment": "^2.10.6",
-        "node-sass": "^3.3.3",
-        "numeral": "^1.5.3",
-        "react": "^0.14.4",
-        "react-addons-test-utils": "^0.14.4",
-        "react-dom": "^0.14.4",
-        "react-hot-loader": "^1.3.0",
-        "sass-loader": "^3.0.0",
-        "source-map-loader": "^0.1.5",
-        "style-loader": "^0.12.4",
-        "url-loader": "^0.5.6",
-        "webpack": "^1.12.2",
-        "webpack-dev-server": "^1.11.0",
-        "webpack-focus": "^0.11.0"
+    "bundle": {
+      "command": "webpack --progress",
+      "env": {
+        "DEV": false,
+        "NODE_ENV": "production",
+        "LIBRARY_NAME": "FocusCore",
+        "MINIMIFY": false,
+        "PACKAGE_JSON_PATH": "../"
+      }
     }
+  },
+  "dependencies": {
+    "flux": "^2.0.3",
+    "i18next-client": "^1.11.4",
+    "immutable": "^3.7.3",
+    "keymirror": "^0.1.1",
+    "lodash": "^3.9.1",
+    "object-assign": "^2.0.0",
+    "uuid": "^2.0.1"
+  },
+  "devDependencies": {
+    "babel": "^6.3.26",
+    "babel-cli": "^6.4.0",
+    "babel-core": "^6.4.0",
+    "babel-eslint": "4.1.3",
+    "babel-loader": "^6.2.1",
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-runtime": "^1.0.7",
+    "babel-plugin-transform-class-properties": "^6.4.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-es2015-classes": "^6.5.2",
+    "babel-plugin-transform-proto-to-assign": "^6.5.0",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
+    "babel-runtime": "^6.3.19",
+    "better-npm-run": "0.0.5",
+    "chai": "^3.2.0",
+    "chai-subset": "^1.1.0",
+    "css-loader": "^0.19.0",
+    "eslint": "1.5.1",
+    "eslint-config-focus": "0.3.0",
+    "eslint-plugin-filenames": "0.1.1",
+    "eslint-plugin-react": "3.5.0",
+    "express": "^4.12.2",
+    "extract-text-webpack-plugin": "^0.8.2",
+    "fbjs": "^0.6.1",
+    "file-loader": "^0.8.4",
+    "jquery": "^2.1.4",
+    "json-loader": "^0.5.3",
+    "mocha": "^2.3.2",
+    "moment": "^2.10.6",
+    "node-sass": "^3.3.3",
+    "numeral": "^1.5.3",
+    "react": "^0.14.4",
+    "react-addons-test-utils": "^0.14.4",
+    "react-dom": "^0.14.4",
+    "react-hot-loader": "^1.3.0",
+    "sass-loader": "^3.0.0",
+    "source-map-loader": "^0.1.5",
+    "style-loader": "^0.12.4",
+    "url-loader": "^0.5.6",
+    "webpack": "^1.12.2",
+    "webpack-dev-server": "^1.11.0",
+    "webpack-focus": "^0.11.0"
+  }
 }

--- a/src/util/props/check.js
+++ b/src/util/props/check.js
@@ -1,0 +1,72 @@
+//TODO in React 15+, use import 'checkReactTypeSpec' from react/src/isomorphic/classic/types/checkReactTypeSpec.js
+import invariant from 'fbjs/lib/invariant';
+import warning from 'fbjs/lib/warning';
+
+const loggedTypeFailures = {};
+let ReactPropTypeLocationNames = {};
+
+if (process.env.NODE_ENV !== 'production') {
+  ReactPropTypeLocationNames = {
+    prop: 'prop',
+    context: 'context',
+    childContext: 'child context'
+  };
+}
+
+/**
+ * Assert that the props are valid
+ *
+ * @param {string} componentName Name of the component for error messages.
+ * @param {object} propTypes Map of prop name to a ReactPropType
+ * @param {object} props
+ * @param {string} location e.g. "prop", "context", "child context"
+ * @private
+ */
+function checkPropTypes(componentName, propTypes, props, location) {
+  for (var propName in propTypes) {
+    if (propTypes.hasOwnProperty(propName)) {
+      var error;
+      // Prop type validation may throw. In case they do, we don't want to
+      // fail the render phase where it didn't fail before. So we log it.
+      // After these have been cleaned up, we'll let them throw.
+      try {
+        // This is intentionally an invariant that gets caught. It's the same
+        // behavior as without this statement except with a better message.
+        invariant(
+          typeof propTypes[propName] === 'function',
+          '%s: %s type `%s` is invalid; it must be a function, usually from ' +
+          'React.PropTypes.',
+          componentName || 'React class',
+          ReactPropTypeLocationNames[location],
+          propName
+        );
+        error = propTypes[propName](props, propName, componentName, location);
+      } catch (ex) {
+        error = ex;
+      }
+      warning(
+        !error || error instanceof Error,
+        '%s: type specification of %s `%s` is invalid; the type checker ' +
+        'function must return `null` or an `Error` but returned a %s. ' +
+        'You may have forgotten to pass an argument to the type checker ' +
+        'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' +
+        'shape all require an argument).',
+        componentName || 'React class',
+        ReactPropTypeLocationNames[location],
+        propName,
+        typeof error
+      );
+      if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+        // Only monitor this failure once because there tends to be a lot of the
+        // same error.
+        loggedTypeFailures[error.message] = true;
+
+        warning(false, 'Failed propType: %s%s', error.message, '');
+      }
+    }
+  }
+}
+
+export default function validatePropTypes(componentName, propTypes, props){
+	return checkPropTypes(componentName, propTypes, props, 'prop');
+};

--- a/src/util/props/index.js
+++ b/src/util/props/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	check: require('./check')
+};


### PR DESCRIPTION
## Feature : Standalone proptypes Validation
### Description

Exporting the same validation React is doing, but accessible.
That way, function could also use PropTypes validation (for example, storeBehaviour, or others)
Had to add fbjs dependencies, to have 'invariant' and 'warning'.

Maybe the method should have an option to throw an exception ?
