### PR TITLE
Fix on getStatusOnNode

### DIFF
--- a/src/store/CoreStore.js
+++ b/src/store/CoreStore.js
@@ -226,7 +226,8 @@ class CoreStore extends EventEmitter {
             currentStore[`getStatus${capitalizeDefinition}`] = function(def){
                 return function getStatus(){
                     const hasData = currentStore.status.has(def);
-                    return hasData ? currentStore.status.get(def) : undefined;
+                    const data = hasData ? currentStore.status.get(def) : undefined;
+                    return data.toJS ? data.toJS() : data;
                 };
             }(definition);
         }

--- a/src/store/CoreStore.js
+++ b/src/store/CoreStore.js
@@ -226,7 +226,7 @@ class CoreStore extends EventEmitter {
             currentStore[`getStatus${capitalizeDefinition}`] = function(def){
                 return function getStatus(){
                     const hasData = currentStore.status.has(def);
-                    return hasData ? currentStore.status.get(def).toJS() : undefined;
+                    return hasData ? currentStore.status.get(def) : undefined;
                 };
             }(definition);
         }


### PR DESCRIPTION
Fix on getStatusOnNode

Correcting the getter on status, which is breaking on toJS, since the element of the map status is a normal object, not an immutable JS one.
