### PR TITLE
[CoreStore] fix get node method

### DIFF
--- a/src/store/CoreStore.js
+++ b/src/store/CoreStore.js
@@ -156,7 +156,7 @@ class CoreStore extends EventEmitter {
                             const rawData = currentStore.data.get(def);
 							if(rawData && rawData.toJS){
 								const data = rawData.toJS();
-								return isEmpty(data) ? undefined : data;
+								return data;
 							}
 							return rawData;
                         }


### PR DESCRIPTION
### Description

Method get for a node should'nt return `undefined` for an empty array

