### PR TITLE
[Dispatcher] Add shorthand for dispatch

### DIFF
--- a/src/dispatcher/index.js
+++ b/src/dispatcher/index.js
@@ -1,11 +1,11 @@
 import { Dispatcher } from 'flux';
-import assign from 'object-assign';
+import isObject from 'lodash/lang/isObject';
 
 /**
 * Application dispatcher.
 * @type {Object}
 */
-const AppDispatcher = assign(new Dispatcher(), {
+const AppDispatcher = Object.assign(new Dispatcher(), {
     /**
     * @param {object} action The details of the action, including the action's
     * type and additional data coming from the server.
@@ -29,5 +29,35 @@ const AppDispatcher = assign(new Dispatcher(), {
         this.dispatch(payload);
     }
 });
+
+/**
+ * Dispatch update data.
+ */
+export function dispatchData() {
+    const firstArgIsObject = isObject(arguments[0]);
+
+    if (firstArgIsObject) { // then form is : dispatchData({ node: data }, identifier);
+        const payload = arguments[0];
+        const identifier = arguments[1];
+
+        AppDispatcher.handleViewAction({
+            data: payload,
+            type: 'update',
+            identifier
+        });
+    } else { // then form is : dispatchData(node, data, identifier);
+        const nodeName = arguments[0];
+        const data = arguments[1];
+        const identifier = arguments[2];
+
+        AppDispatcher.handleViewAction({
+            data: {
+                [nodeName]: data
+            },
+            type: 'update',
+            identifier
+        });
+    }
+}
 
 export default AppDispatcher;


### PR DESCRIPTION
Resolves #414 

### Description

Add a shorthand method to dispatch data.

### Example

two forms (identifier is optional) :

```jsx
import { dispatchData } from 'focus-core/dispatcher';

dispatchData(node, data, identifier);
// Or
dispatchData({ node1: data1, node2: data2 }, identifier);
```
