### PR TITLE
Fetch - Correct error handling

### DIFF
--- a/src/network/fetch.js
+++ b/src/network/fetch.js
@@ -107,8 +107,10 @@ function wrappingFetch({ url, method, data }, options) {
         }).then(response => {
             updateRequestStatus({ id: requestStatus.id, status: response.ok ? 'success' : 'error' });
             const contentType = response.headers.get('content-type');
-            checkErrors(response, xhrErrors);
             return getResponseContent(response, reqOptions.dataType ? reqOptions.dataType : contentType && contentType.includes('application/json') ? 'json' : 'text');
+        }).catch(data => {
+            checkErrors(data, xhrErrors);
+            return Promise.reject(data);
         });
 }
 


### PR DESCRIPTION
Response can be read only once, so if we want to go through check errors and have access to data, it should be done like this